### PR TITLE
plat/rpi: implement PSCI CPU_OFF.

### DIFF
--- a/plat/rpi/common/rpi3_pm.c
+++ b/plat/rpi/common/rpi3_pm.c
@@ -162,6 +162,29 @@ static void rpi3_pwr_domain_on_finish(const psci_power_state_t *target_state)
 #endif
 }
 
+static void __dead2 rpi3_pwr_down_wfi(
+		const psci_power_state_t *target_state)
+{
+	uint64_t *hold_base = (uint64_t *)PLAT_RPI3_TM_HOLD_BASE;
+	unsigned int pos = plat_my_core_pos();
+
+	if (pos == 0) {
+		/*
+		 * The secondaries will always be in a wait
+		 * for warm boot on reset, but the BSP needs
+		 * to be able to distinguish between waiting
+		 * for warm boot (e.g. after psci_off, waiting
+		 * for psci_on) and a cold boot.
+		 */
+		hold_base[pos] = PLAT_RPI3_TM_HOLD_STATE_BSP_OFF;
+		dsb();
+		isb();
+	}
+
+	write_rmr_el3(RMR_EL3_RR_BIT | RMR_EL3_AA64_BIT);
+	while(1);
+}
+
 /*******************************************************************************
  * Platform handlers for system reset and system off.
  ******************************************************************************/
@@ -226,6 +249,7 @@ static const plat_psci_ops_t plat_rpi3_psci_pm_ops = {
 	.pwr_domain_off = rpi3_pwr_domain_off,
 	.pwr_domain_on = rpi3_pwr_domain_on,
 	.pwr_domain_on_finish = rpi3_pwr_domain_on_finish,
+	.pwr_domain_pwr_down_wfi = rpi3_pwr_down_wfi,
 	.system_off = rpi3_system_off,
 	.system_reset = rpi3_system_reset,
 	.validate_power_state = rpi3_validate_power_state,

--- a/plat/rpi/rpi3/aarch64/plat_helpers.S
+++ b/plat/rpi/rpi3/aarch64/plat_helpers.S
@@ -62,21 +62,19 @@ func plat_is_my_cpu_primary
 endfunc plat_is_my_cpu_primary
 
 	/* -----------------------------------------------------
-	 * void plat_secondary_cold_boot_setup (void);
+	 * void plat_wait_for_warm_boot (void);
 	 *
 	 * This function performs any platform specific actions
-	 * needed for a secondary cpu after a cold reset e.g
-	 * mark the cpu's presence, mechanism to place it in a
-	 * holding pen etc.
+	 * needed for a CPU to be put into holding pen to wait
+	 * for a warm boot request.
 	 * -----------------------------------------------------
 	 */
-func plat_secondary_cold_boot_setup
+func plat_wait_for_warm_boot
 	/* Calculate address of our hold entry */
 	bl	plat_my_core_pos
 	lsl	x0, x0, #3
 	mov_imm	x2, PLAT_RPI3_TM_HOLD_BASE
 	add	x0, x0, x2
-
 	/*
 	 * This code runs way before requesting the warmboot of this core,
 	 * so it is possible to clear the mailbox before getting a request
@@ -84,8 +82,11 @@ func plat_secondary_cold_boot_setup
 	 */
 	mov	x1, PLAT_RPI3_TM_HOLD_STATE_WAIT
 	str	x1,[x0]
-
-	/* Wait until we have a go */
+	/*
+	 * Wait until we have a go - the sevl deals with the race
+	 * of someone setting a GO state before our wfe.
+	 */
+	sevl
 poll_mailbox:
 	wfe
 	ldr	x1, [x0]
@@ -96,6 +97,19 @@ poll_mailbox:
 	mov_imm	x0, PLAT_RPI3_TM_ENTRYPOINT
 	ldr	x1, [x0]
 	br	x1
+endfunc plat_wait_for_warm_boot
+
+	/* -----------------------------------------------------
+	 * void plat_secondary_cold_boot_setup (void);
+	 *
+	 * This function performs any platform specific actions
+	 * needed for a secondary cpu after a cold reset e.g
+	 * mark the cpu's presence, mechanism to place it in a
+	 * holding pen etc.
+	 * -----------------------------------------------------
+	 */
+func plat_secondary_cold_boot_setup
+	b	plat_wait_for_warm_boot
 endfunc plat_secondary_cold_boot_setup
 
 	/* ---------------------------------------------------------------------
@@ -110,8 +124,25 @@ endfunc plat_secondary_cold_boot_setup
 	 * ---------------------------------------------------------------------
 	 */
 func plat_get_my_entrypoint
-	/* TODO: support warm boot */
-	mov	x0, #0
+	mov	x1, x30
+	bl	plat_is_my_cpu_primary
+	mov	x30, x1
+	/*
+	 * Secondaries always cold boot.
+	*/
+	cbz	w0, 1f
+	/*
+	 * Primaries warm boot if they are requested
+	 * to power off.
+	 */
+	mov_imm	x0, PLAT_RPI3_TM_HOLD_BASE
+	ldr	x0, [x0]
+	cmp	x0, PLAT_RPI3_TM_HOLD_STATE_BSP_OFF
+	bne	1f
+	adr	x0, plat_wait_for_warm_boot
+	mov	x30, x1
+	ret
+1:	mov	x0, #0
 	ret
 endfunc plat_get_my_entrypoint
 

--- a/plat/rpi/rpi3/include/platform_def.h
+++ b/plat/rpi/rpi3/include/platform_def.h
@@ -153,6 +153,7 @@
 
 #define PLAT_RPI3_TM_HOLD_STATE_WAIT	ULL(0)
 #define PLAT_RPI3_TM_HOLD_STATE_GO	ULL(1)
+#define PLAT_RPI3_TM_HOLD_STATE_BSP_OFF	ULL(2)
 
 /*
  * BL1 specific defines.

--- a/plat/rpi/rpi4/aarch64/plat_helpers.S
+++ b/plat/rpi/rpi4/aarch64/plat_helpers.S
@@ -64,21 +64,19 @@ func plat_is_my_cpu_primary
 endfunc plat_is_my_cpu_primary
 
 	/* -----------------------------------------------------
-	 * void plat_secondary_cold_boot_setup (void);
+	 * void plat_wait_for_warm_boot (void);
 	 *
 	 * This function performs any platform specific actions
-	 * needed for a secondary cpu after a cold reset e.g
-	 * mark the cpu's presence, mechanism to place it in a
-	 * holding pen etc.
+	 * needed for a CPU to be put into holding pen to wait
+	 * for a warm boot request.
 	 * -----------------------------------------------------
 	 */
-func plat_secondary_cold_boot_setup
+func plat_wait_for_warm_boot
 	/* Calculate address of our hold entry */
 	bl	plat_my_core_pos
 	lsl	x0, x0, #3
 	mov_imm	x2, PLAT_RPI3_TM_HOLD_BASE
 	add	x0, x0, x2
-
 	/*
 	 * This code runs way before requesting the warmboot of this core,
 	 * so it is possible to clear the mailbox before getting a request
@@ -86,8 +84,11 @@ func plat_secondary_cold_boot_setup
 	 */
 	mov	x1, PLAT_RPI3_TM_HOLD_STATE_WAIT
 	str	x1,[x0]
-
-	/* Wait until we have a go */
+	/*
+	 * Wait until we have a go - the sevl deals with the race
+	 * of someone setting a GO state before our wfe.
+	 */
+	sevl
 poll_mailbox:
 	wfe
 	ldr	x1, [x0]
@@ -98,6 +99,19 @@ poll_mailbox:
 	mov_imm	x0, PLAT_RPI3_TM_ENTRYPOINT
 	ldr	x1, [x0]
 	br	x1
+endfunc plat_wait_for_warm_boot
+
+	/* -----------------------------------------------------
+	 * void plat_secondary_cold_boot_setup (void);
+	 *
+	 * This function performs any platform specific actions
+	 * needed for a secondary cpu after a cold reset e.g
+	 * mark the cpu's presence, mechanism to place it in a
+	 * holding pen etc.
+	 * -----------------------------------------------------
+	 */
+func plat_secondary_cold_boot_setup
+	b	plat_wait_for_warm_boot
 endfunc plat_secondary_cold_boot_setup
 
 	/* ---------------------------------------------------------------------
@@ -112,8 +126,25 @@ endfunc plat_secondary_cold_boot_setup
 	 * ---------------------------------------------------------------------
 	 */
 func plat_get_my_entrypoint
-	/* TODO: support warm boot */
-	mov	x0, #0
+	mov	x1, x30
+	bl	plat_is_my_cpu_primary
+	mov	x30, x1
+	/*
+	 * Secondaries always cold boot.
+	*/
+	cbz	w0, 1f
+	/*
+	 * Primaries warm boot if they are requested
+	 * to power off.
+	 */
+	mov_imm	x0, PLAT_RPI3_TM_HOLD_BASE
+	ldr	x0, [x0]
+	cmp	x0, PLAT_RPI3_TM_HOLD_STATE_BSP_OFF
+	bne	1f
+	adr	x0, plat_wait_for_warm_boot
+	mov	x30, x1
+	ret
+1:	mov	x0, #0
 	ret
 endfunc plat_get_my_entrypoint
 

--- a/plat/rpi/rpi4/include/platform_def.h
+++ b/plat/rpi/rpi4/include/platform_def.h
@@ -93,6 +93,7 @@
 
 #define PLAT_RPI3_TM_HOLD_STATE_WAIT	ULL(0)
 #define PLAT_RPI3_TM_HOLD_STATE_GO	ULL(1)
+#define PLAT_RPI3_TM_HOLD_STATE_BSP_OFF	ULL(2)
 
 /*
  * BL31 specific defines.


### PR DESCRIPTION
See https://developer.trustedfirmware.org/T686

We simulate CPU off by reseting core via RMR. For secondaries,
that already puts them in the holding pen waiting for a
"warm boot" request as part of PSCI CPU_ON. For the BSP,
we have to add logic to distinguish a regular boot from
a CPU_OFF state, where like the secondaries, the BSP
needs to wait foor a "warm boot" request as part of CPU_ON.

I didn't bother refactoring out the common code out of
platform_defs.h and palt_helpers.S to keep this clear.
These Pi 3/4 files were mostly identical even before this
change.

Testing:

- ACS suite now passes more tests (since it repeatedly
calls code on secondaries via CPU_ON).

- Linux testing including offlining/onlineing CPU0, e.g.
"echo 0 > /sys/devices/system/cpu/cpu0/online".

Signed-off-by: Andrei Warkentin <andrey.warkentin@gmail.com>